### PR TITLE
Refactor scraping code into modules

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -1,0 +1,44 @@
+import os
+import re
+import unicodedata
+
+
+def clean_name(name: str) -> str:
+    nfkd = unicodedata.normalize('NFKD', name)
+    only_ascii = nfkd.encode('ASCII', 'ignore').decode('ASCII')
+    return only_ascii.lower().replace('-', ' ').strip()
+
+
+def clean_filename(name: str) -> str:
+    nfkd = unicodedata.normalize('NFKD', name)
+    only_ascii = nfkd.encode('ASCII', 'ignore').decode('ASCII')
+    safe = re.sub(r"[^a-zA-Z0-9\- ]", "", only_ascii)
+    safe = safe.replace(" ", "-").lower()
+    return safe
+
+
+def charger_liens_avec_id(base_dir: str) -> dict:
+    """Charge le mapping ID -> URL depuis le fichier liens_avec_id.txt."""
+    id_url_map = {}
+    liens_id_txt = os.path.join(base_dir, "liens_avec_id.txt")
+    if not os.path.exists(liens_id_txt):
+        print(f"Fichier introuvable : {liens_id_txt}")
+        return id_url_map
+    with open(liens_id_txt, "r", encoding="utf-8") as f:
+        for line in f:
+            parts = line.strip().split(" ", 1)
+            if len(parts) == 2:
+                identifiant, url = parts
+                id_url_map[identifiant.upper()] = url
+    return id_url_map
+
+
+def extraire_ids_depuis_input(input_str: str) -> list:
+    try:
+        start_id, end_id = input_str.upper().split("-")
+        start_num = int(start_id[1:])
+        end_num = int(end_id[1:])
+        return [f"A{i}" for i in range(start_num, end_num + 1)]
+    except Exception:
+        print("⚠️ Format invalide. Utilise le format A1-A5.")
+        return []

--- a/main.py
+++ b/main.py
@@ -1,2 +1,37 @@
+import os
+from core.utils import charger_liens_avec_id, extraire_ids_depuis_input
+from core.scraper import scrap_produits_par_ids, scrap_fiches_concurrents, export_fiches_concurrents_json
+
+
+def demander_base_dir() -> str:
+    default_dir = os.getcwd()
+    rep = input(f"\U0001f4c2 Dossier de travail (Entr\u00e9e pour '{default_dir}'): ").strip()
+    return rep or default_dir
+
+
 if __name__ == "__main__":
     print("Bienvenue dans l'application de scraping!")
+    base_dir = demander_base_dir()
+
+    id_url_map = charger_liens_avec_id(base_dir)
+    plage_input = input("\U0001f7e2 Quels identifiants veux-tu scraper ? (ex: A1-A5): ").strip()
+    ids_selectionnes = extraire_ids_depuis_input(plage_input)
+
+    if not ids_selectionnes:
+        print("\u26d4 Aucun ID valide fourni. Arr\u00eat du script.")
+        exit()
+
+    if input("\u25b6\ufe0f Lancer le scraping des variantes ? (oui/non): ").strip().lower() == "oui":
+        scrap_produits_par_ids(id_url_map, ids_selectionnes, base_dir)
+
+    if input("\u25b6\ufe0f Lancer le scraping des fiches produits concurrents ? (oui/non): ").strip().lower() == "oui":
+        scrap_fiches_concurrents(id_url_map, ids_selectionnes, base_dir)
+
+    if input("\u25b6\ufe0f Voulez-vous exporter les fiches produits concurrents en lots JSON\u202f? (oui/non): ").strip().lower() == "oui":
+        try:
+            taille = input("  \ud83d\udd39 Taille des lots (appuie Entr\u00e9e pour 5): ").strip()
+            taille_batch = int(taille) if taille else 5
+        except Exception:
+            print("\u26a0\ufe0f Valeur invalide, on utilise la taille 5 par d\u00e9faut.")
+            taille_batch = 5
+        export_fiches_concurrents_json(base_dir, taille_batch)


### PR DESCRIPTION
## Summary
- delete the monolithic `code_source.py`
- create `core/utils.py` with helper functions
- create `core/scraper.py` with scraping and export logic
- update `main.py` with a small console interface and dynamic base path
- use webdriver-manager to automatically handle ChromeDriver

## Testing
- `python -m py_compile main.py core/utils.py core/scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_684379bd619c8330a8f17f205c362b9b