### PR TITLE
Refonte de l'interface PySide6 en mode sombre

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-dotenv
 tqdm
 flake8
 webdriver-manager
+qtawesome


### PR DESCRIPTION
## Summary
- add qtawesome to requirements for icons
- rebuild `interface.py` with a dark theme QSS
- modernize widgets: file picker, ID checklist with search, actions menu, sliders
- add settings with headless and dark mode options and a detailed guide

## Testing
- `flake8`
- `python -m py_compile interface.py`

------
https://chatgpt.com/codex/tasks/task_e_68438ee1846c8330b9fe09020a0bc672