### PR TITLE
Add sys path hack for prototype

### DIFF
--- a/NEW_APPLICATION_EN_DEV/interface_dev.py
+++ b/NEW_APPLICATION_EN_DEV/interface_dev.py
@@ -1,3 +1,8 @@
+# Only for running the prototype directly
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 import os
 import re
 import sys


### PR DESCRIPTION
## Summary
- add path hack to `interface_dev.py` for running the prototype directly

## Testing
- `python -m py_compile NEW_APPLICATION_EN_DEV/interface_dev.py`

------
https://chatgpt.com/codex/tasks/task_e_6843a091c26c8330b18c41b404f9a6cf