### PR TITLE
Add dark QSS theme and animated progress bar

### DIFF
--- a/application_definitif.py
+++ b/application_definitif.py
@@ -3,7 +3,14 @@ import re
 import sys
 import time
 
-from PySide6.QtCore import Signal, QObject, QThread, Qt
+from PySide6.QtCore import (
+    Signal,
+    QObject,
+    QThread,
+    Qt,
+    QPropertyAnimation,
+    QEasingCurve,
+)
 from PySide6.QtWidgets import (
     QApplication,
     QFileDialog,
@@ -205,7 +212,12 @@ class MainWindow(QMainWindow):
         super().__init__()
         self.setWindowTitle("Scraping Produit")
         self.resize(850, 600)
-        self.setStyleSheet(DARK_STYLE)
+        style_path = os.path.join(os.path.dirname(__file__), "ui", "style.qss")
+        try:
+            with open(style_path, "r", encoding="utf-8") as f:
+                self.setStyleSheet(f.read())
+        except OSError:
+            self.setStyleSheet(DARK_STYLE)
 
         self.links_path = ""
         self.id_url_map: dict[str, str] = {}
@@ -495,7 +507,7 @@ La barre de progression et le minuteur indiquent l'avancement."""
         elapsed: float,
         remaining: float,
     ) -> None:
-        self.progress.setValue(percent)
+        self.progress.set_animated_value(percent)
         txt = (
             f"Temps écoulé: {int(elapsed)}s | "
             f"Temps restant estimé: {int(remaining)}s"
@@ -521,6 +533,15 @@ class ProgressBar(QProgressBar):
         super().__init__()
         self.setRange(0, 100)
         self.setValue(0)
+        self._anim = QPropertyAnimation(self, b"value")
+        self._anim.setDuration(300)
+        self._anim.setEasingCurve(QEasingCurve.InOutCubic)
+
+    def set_animated_value(self, value: int) -> None:
+        self._anim.stop()
+        self._anim.setStartValue(self.value())
+        self._anim.setEndValue(value)
+        self._anim.start()
 
 
 def main() -> None:

--- a/ui/style.qss
+++ b/ui/style.qss
@@ -1,0 +1,48 @@
+/* Dark professional palette */
+QMainWindow, QWidget {
+    background-color: #2b2b2b;
+    color: #dddddd;
+    font-family: Arial, sans-serif;
+    font-size: 10pt;
+}
+
+QLineEdit, QTextEdit {
+    background-color: #3c3c3c;
+    color: #eeeeee;
+    border: 1px solid #555555;
+    border-radius: 4px;
+    padding: 2px 4px;
+}
+
+QPushButton, QToolButton {
+    background-color: #444444;
+    color: #eeeeee;
+    border: 1px solid #666666;
+    border-radius: 6px;
+    padding: 2px 6px;
+}
+
+QPushButton:hover, QToolButton:hover { background-color: #555555; }
+QPushButton:checked, QToolButton:checked { background-color: #0078d7; }
+
+QProgressBar {
+    background-color: #3c3c3c;
+    border: 1px solid #555555;
+    border-radius: 6px;
+    text-align: center;
+    height: 16px;
+}
+QProgressBar::chunk {
+    border-radius: 6px;
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #0078d7, stop:1 #00c2ff);
+}
+
+QTabWidget::pane { border: 1px solid #444444; }
+QTabBar::tab {
+    background: #444444;
+    color: #eeeeee;
+    padding: 4px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+}
+QTabBar::tab:selected { background: #0078d7; }


### PR DESCRIPTION
## Summary
- provide a new reusable `ui/style.qss` dark palette with tight spacings
- load that stylesheet from `application_definitif.py`
- animate progress updates with `QPropertyAnimation`

## Testing
- `python -m py_compile application_definitif.py`
- `python -m py_compile NEW_APPLICATION_EN_DEV/interface_dev.py`


------
https://chatgpt.com/codex/tasks/task_e_6844179d353c8330adc42e025d11a533