### PR TITLE
Refine scraping tab layout

### DIFF
--- a/NEW_APPLICATION_EN_DEV/interface_dev.py
+++ b/NEW_APPLICATION_EN_DEV/interface_dev.py
@@ -222,6 +222,8 @@ class MainWindow(QMainWindow):
     def _build_scraping_tab(self) -> QWidget:
         widget = QWidget()
         layout = QVBoxLayout(widget)
+        layout.setSpacing(2)
+        layout.setContentsMargins(4, 4, 4, 4)
 
         self.file_info = QLabel("Aucun fichier chargé")
         layout.addWidget(self.file_info)
@@ -244,6 +246,7 @@ class MainWindow(QMainWindow):
         layout.addLayout(range_layout)
 
         self.count_label = QLabel("0/0")
+        self.count_label.setAlignment(Qt.AlignRight)
         layout.addWidget(self.count_label)
 
         action_layout = QHBoxLayout()
@@ -255,6 +258,7 @@ class MainWindow(QMainWindow):
         self.btn_export.setCheckable(True)
         for b in (self.btn_variantes, self.btn_fiches, self.btn_export):
             b.setStyleSheet("QPushButton:checked{background-color:#0078d7;}")
+            b.setFixedHeight(28)
         action_layout.addWidget(self.btn_variantes)
         action_layout.addWidget(self.btn_fiches)
         action_layout.addWidget(self.btn_export)
@@ -265,9 +269,9 @@ class MainWindow(QMainWindow):
         layout.addWidget(self.launch_btn)
 
         self.progress = ProgressBar()
-        layout.addWidget(self.progress)
 
         status_layout = QHBoxLayout()
+        status_layout.setAlignment(Qt.AlignRight)
         self.status_var = QLabel()
         self.status_fiche = QLabel()
         self.status_export = QLabel()
@@ -276,7 +280,12 @@ class MainWindow(QMainWindow):
         status_layout.addWidget(self.status_var)
         status_layout.addWidget(self.status_fiche)
         status_layout.addWidget(self.status_export)
-        layout.addLayout(status_layout)
+
+        progress_line = QHBoxLayout()
+        progress_line.addWidget(self.progress, 1)
+        progress_line.addStretch(1)
+        progress_line.addLayout(status_layout)
+        layout.addLayout(progress_line)
 
         self.time_label = QLabel("Temps écoulé: 0s | Temps restant estimé: ?")
         layout.addWidget(self.time_label)

--- a/application_definitif.py
+++ b/application_definitif.py
@@ -234,8 +234,8 @@ class MainWindow(QMainWindow):
     def _build_scraping_tab(self) -> QWidget:
         widget = QWidget()
         layout = QVBoxLayout(widget)
-        layout.setSpacing(4)
-        layout.setContentsMargins(6, 6, 6, 6)
+        layout.setSpacing(2)
+        layout.setContentsMargins(4, 4, 4, 4)
 
         self.total_links_label = QLabel("Nombre de liens total : 0")
         f = self.total_links_label.font()
@@ -262,7 +262,7 @@ class MainWindow(QMainWindow):
         layout.addLayout(range_layout)
 
         self.count_label = QLabel("IDs sélectionnés : 0/0")
-        self.count_label.setAlignment(Qt.AlignCenter)
+        self.count_label.setAlignment(Qt.AlignRight)
         layout.addWidget(self.count_label)
 
         action_layout = QHBoxLayout()
@@ -289,6 +289,7 @@ class MainWindow(QMainWindow):
                 "QToolButton {padding:2px 6px;}"
                 "QToolButton:checked{background-color:#0078d7;}"
             )
+            b.setFixedHeight(28)
         action_layout.addWidget(self.btn_variantes)
         action_layout.addWidget(self.btn_fiches)
         action_layout.addWidget(self.btn_export)
@@ -301,6 +302,7 @@ class MainWindow(QMainWindow):
         self.progress = AnimatedProgressBar()
         status_layout = QHBoxLayout()
         status_layout.setSpacing(4)
+        status_layout.setAlignment(Qt.AlignRight)
         self.status_var = QLabel()
         self.status_fiche = QLabel()
         self.status_export = QLabel()
@@ -310,6 +312,7 @@ class MainWindow(QMainWindow):
             )
         progress_line = QHBoxLayout()
         progress_line.addWidget(self.progress, 1)
+        progress_line.addStretch(1)
         progress_line.addLayout(status_layout)
         status_layout.addWidget(self.status_var)
         status_layout.addWidget(self.status_fiche)


### PR DESCRIPTION
## Summary
- reduce spacing and margins in `MainWindow._build_scraping_tab`
- fix action button arrangement and sizing
- right-align the ID count and status labels for a more compact layout

## Testing
- `flake8 || true`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684419f246b48330aaa8971ff1ca4f1b