### PR TITLE
Implement theme persistence

### DIFF
--- a/ui/light.qss
+++ b/ui/light.qss
@@ -1,0 +1,48 @@
+/* Light professional palette */
+QMainWindow, QWidget {
+    background-color: #f0f0f0;
+    color: #222;
+    font-family: Arial, sans-serif;
+    font-size: 10pt;
+}
+
+QLineEdit, QTextEdit {
+    background-color: #ffffff;
+    color: #222;
+    border: 1px solid #aaaaaa;
+    border-radius: 4px;
+    padding: 2px 4px;
+}
+
+QPushButton, QToolButton {
+    background-color: #e0e0e0;
+    color: #222;
+    border: 1px solid #bbbbbb;
+    border-radius: 6px;
+    padding: 2px 6px;
+}
+
+QPushButton:hover, QToolButton:hover { background-color: #d0d0d0; }
+QPushButton:checked, QToolButton:checked { background-color: #0078d7; }
+
+QProgressBar {
+    background-color: #ffffff;
+    border: 1px solid #aaaaaa;
+    border-radius: 6px;
+    text-align: center;
+    height: 16px;
+}
+QProgressBar::chunk {
+    border-radius: 6px;
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #0078d7, stop:1 #00c2ff);
+}
+
+QTabWidget::pane { border: 1px solid #bbbbbb; }
+QTabBar::tab {
+    background: #e0e0e0;
+    color: #222;
+    padding: 4px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+}
+QTabBar::tab:selected { background: #0078d7; }


### PR DESCRIPTION
## Summary
- add a light QSS theme
- allow switching between dark and light themes with checkbox
- remember selected theme using QSettings

## Testing
- `python -m py_compile application_definitif.py NEW_APPLICATION_EN_DEV/interface_dev.py`

------
https://chatgpt.com/codex/tasks/task_e_68441d0c0934833082f6cd884a115b82