### PR TITLE
Fix QAction import for PySide6 6.9

### DIFF
--- a/NEW_APPLICATION_EN_DEV/interface_scraper_liens.py
+++ b/NEW_APPLICATION_EN_DEV/interface_scraper_liens.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import List
 
 from PySide6.QtCore import Qt, QThread, Signal
+from PySide6.QtGui import QAction
 from PySide6.QtWidgets import (
     QApplication,
     QFileDialog,
@@ -17,7 +18,6 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QWidget,
     QPlainTextEdit,
-    QAction,
 )
 
 from .scraper_liens import scrape_links


### PR DESCRIPTION
## Summary
- correct PySide6 QAction import for the standalone scraper GUI

## Testing
- `flake8 NEW_APPLICATION_EN_DEV/interface_scraper_liens.py` *(fails: F401, E501)*
- `python - <<'EOF'
import importlib
m = importlib.import_module('NEW_APPLICATION_EN_DEV.interface_scraper_liens')
print('loaded', m.__name__)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68442d0c24188330a4f85645e7cccf43