### PR TITLE
Add QtWebEngine dependency note

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Interface graphique épurée, facile à prendre en main
 Dépendances principales
 PySide6 – interface graphique
 
+QtWebEngine – nécessaire pour le navigateur intégré (package PySide6-Qt6-WebEngine)
+
 requests – requêtes HTTP simples
 
 selenium – scraping dynamique


### PR DESCRIPTION
## Summary
- mention that QtWebEngine is needed via the `PySide6-Qt6-WebEngine` package

## Testing
- `flake8` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_68443dfffe708330b0557ba5ef74b8e7