### PR TITLE
Add external browser with IPC for selector tool

### DIFF
--- a/NEW_APPLICATION_EN_DEV/inspecteur_selector/requirements.txt
+++ b/NEW_APPLICATION_EN_DEV/inspecteur_selector/requirements.txt
@@ -2,3 +2,4 @@ PySide6
 PySide6-Qt6-WebEngine
 selenium
 webdriver-manager
+websockets

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ tqdm
 flake8
 webdriver-manager
 qtawesome
+websockets


### PR DESCRIPTION
## Summary
- rework inspecteur selector browser to open Chrome/Chromium externally
- detect browser location on Windows, macOS or Linux
- start a WebSocket server and inject JS to forward selectors
- update requirements with websockets

## Testing
- `flake8 NEW_APPLICATION_EN_DEV/inspecteur_selector/inspecteur_selector.py`

------
https://chatgpt.com/codex/tasks/task_e_6844477273288330a6f62fb0da82a149