### PR TITLE
Add basic selector capturing Chrome extension

### DIFF
--- a/NEW_APPLICATION_EN_DEV/inspecteur_selector/README.md
+++ b/NEW_APPLICATION_EN_DEV/inspecteur_selector/README.md
@@ -36,3 +36,12 @@ Exécutez `python inspecteur_selector.py` puis :
 ## Limitations
 
 Ce prototype sert uniquement de démonstrateur et n'inclut pas de gestion avancée des erreurs. L'XPath proposé est généré via un simple script JavaScript et peut ne pas couvrir tous les cas.
+
+## Extension Chrome
+
+Une extension minimaliste se trouve dans `chrome_extension/`. Pour la charger :
+
+1. Ouvrez Chrome et accédez à `chrome://extensions/`.
+2. Activez le mode développeur (coin supérieur droit).
+3. Cliquez sur *Charger l'extension non empaquetée* et sélectionnez le dossier `chrome_extension`.
+4. Lors d'un clic droit sur une page, l'extension enverra le sélecteur CSS et l'XPath de l'élément au serveur WebSocket (`ws://localhost:8765`).

--- a/NEW_APPLICATION_EN_DEV/inspecteur_selector/chrome_extension/content.js
+++ b/NEW_APPLICATION_EN_DEV/inspecteur_selector/chrome_extension/content.js
@@ -1,0 +1,57 @@
+(function(){
+  if (window.__selector_ws) return;
+  var ws = new WebSocket('ws://localhost:8765');
+  window.__selector_ws = ws;
+
+  function cssPath(el){
+    var path = [];
+    while (el && el.nodeType === 1){
+      var selector = el.nodeName.toLowerCase();
+      if (el.id){
+        selector += '#' + el.id;
+        path.unshift(selector);
+        break;
+      } else {
+        var sib = el, nth = 1;
+        while (sib = sib.previousElementSibling){
+          if (sib.nodeName.toLowerCase() === selector) nth++;
+        }
+        if (nth !== 1) selector += ':nth-of-type(' + nth + ')';
+      }
+      path.unshift(selector);
+      el = el.parentNode;
+    }
+    return path.join(' > ');
+  }
+
+  function getXPath(el){
+    if (el.id) return '//' + el.tagName.toLowerCase() + '[@id="' + el.id + '"]';
+    if (el === document.body) return '/html/body';
+    var ix = 0;
+    var siblings = el.parentNode.childNodes;
+    for (var i=0; i<siblings.length; i++){
+      var sib = siblings[i];
+      if (sib === el) {
+        return getXPath(el.parentNode) + '/' + el.tagName.toLowerCase() + '[' + (ix+1) + ']';
+      }
+      if (sib.nodeType === 1 && sib.tagName === el.tagName) {
+        ix++;
+      }
+    }
+  }
+
+  document.addEventListener('contextmenu', function(e){
+    var msg = {
+      css: cssPath(e.target),
+      xpath: getXPath(e.target)
+    };
+    var data = JSON.stringify(msg);
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(data);
+    } else {
+      ws.addEventListener('open', function(){
+        ws.send(data);
+      }, {once: true});
+    }
+  }, true);
+})();

--- a/NEW_APPLICATION_EN_DEV/inspecteur_selector/chrome_extension/manifest.json
+++ b/NEW_APPLICATION_EN_DEV/inspecteur_selector/chrome_extension/manifest.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 3,
+  "name": "Selector Inspector",
+  "version": "0.1",
+  "description": "Send CSS selector or XPath to the PySide app via WebSocket.",
+  "host_permissions": ["<all_urls>"],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Chrome extension for selector capture in `chrome_extension/`
- document how to load the extension

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844491047408330b2a2b6bb6d164f06