### PR TITLE
Make inspecteur selector pluggable

### DIFF
--- a/NEW_APPLICATION_EN_DEV/inspecteur_selector/README.md
+++ b/NEW_APPLICATION_EN_DEV/inspecteur_selector/README.md
@@ -89,3 +89,18 @@ Si aucun sélecteur n'est reçu :
   pare‑feu ou un logiciel de sécurité.
 * Fermez toutes les fenêtres Chrome/Chromium avant de relancer le programme,
   afin que Selenium puisse ouvrir une nouvelle instance avec le bon port.
+
+## Modules de scraping
+
+Le navigateur s'appuie sur des fonctions de scraping externes. Par défaut,
+`scraper_liens.scrape_links` est utilisé. Vous pouvez ajouter vos propres
+modules en définissant la variable d'environnement `INSPECTEUR_SCRAPERS` sous la
+forme `nom=module:fonction` (séparés par des virgules).
+
+```bash
+INSPECTEUR_SCRAPERS="Liens=scraper_liens:scrape_links,Images=mon_module:grab"
+```
+
+Chaque fonction doit accepter `url` et `selector` et retourner la liste des
+liens extraits. Les modules ainsi déclarés apparaîtront dans la liste déroulante
+de l'interface.

--- a/NEW_APPLICATION_EN_DEV/scraper_liens.py
+++ b/NEW_APPLICATION_EN_DEV/scraper_liens.py
@@ -14,7 +14,10 @@ def scrape_links(url: str, selector: str) -> list[str]:
     """
     options = webdriver.ChromeOptions()
     options.add_argument("--headless")
-    driver = webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=options)
+    driver = webdriver.Chrome(
+        service=Service(ChromeDriverManager().install()),
+        options=options,
+    )
 
     links: list[str] = []
     try:


### PR DESCRIPTION
## Summary
- add `Scraper` protocol and `load_scrapers` helper
- choose scraper function in the GUI
- allow configuring scrapers through `INSPECTEUR_SCRAPERS`
- document adding new scrapers

## Testing
- `flake8 NEW_APPLICATION_EN_DEV/inspecteur_selector/inspecteur_selector.py NEW_APPLICATION_EN_DEV/scraper_liens.py`
- `python -m py_compile NEW_APPLICATION_EN_DEV/inspecteur_selector/inspecteur_selector.py NEW_APPLICATION_EN_DEV/scraper_liens.py`


------
https://chatgpt.com/codex/tasks/task_e_68444bb266b08330b71318f8fdeb345e