### PR TITLE
Fix batch size message in JSON export

### DIFF
--- a/core/scraper.py
+++ b/core/scraper.py
@@ -290,7 +290,6 @@ def export_fiches_concurrents_json(
         print(f"    ➡️ Batch sauvegardé : {nom_fichier_sortie}")
 
     print(
-        "\n✅ Export JSON terminé avec lots de 5 produits. "
-        "Fichiers créés dans :",
-        dossier_sortie,
+        f"\n✅ Export JSON terminé avec lots de {taille_batch} produits. "
+        f"Fichiers créés dans : {dossier_sortie}"
     )


### PR DESCRIPTION
## Summary
- improve the export message in `export_fiches_concurrents_json`

## Testing
- `python -m py_compile core/scraper.py`
- `python -m py_compile main.py application_definitif.py`


------
https://chatgpt.com/codex/tasks/task_e_684459ae0f488330ad6919820983e887