### PR TITLE
Fix directory naming for competitor sheets

### DIFF
--- a/application_definitif.py
+++ b/application_definitif.py
@@ -125,7 +125,7 @@ class ScrapingWorker(QThread):
             self.totals["fiches"] = len(self.ids)
         if actions.get("export"):
             fc_dir = self.session_paths["fiches"]
-            src = os.path.join(fc_dir, "fiche concurrents")
+            src = os.path.join(fc_dir, "fiches_concurrents")
             txt_files = []
             if os.path.isdir(src):
                 txt_files = [f for f in os.listdir(src) if f.endswith(".txt")]

--- a/core/scraper.py
+++ b/core/scraper.py
@@ -159,7 +159,7 @@ def scrap_fiches_concurrents(
     ids_selectionnes: list,
     base_dir: str,
 ) -> None:
-    save_directory = os.path.join(base_dir, "fiche concurrents")
+    save_directory = os.path.join(base_dir, "fiches_concurrents")
     recap_excel_path = os.path.join(base_dir, "recap_concurrents.xlsx")
     driver = _get_driver(headless=False)
 
@@ -240,7 +240,7 @@ def export_fiches_concurrents_json(
     base_dir: str,
     taille_batch: int = 5,
 ) -> None:
-    dossier_source = os.path.join(base_dir, "fiche concurrents")
+    dossier_source = os.path.join(base_dir, "fiches_concurrents")
     dossier_sortie = os.path.join(dossier_source, "batches_json")
     os.makedirs(dossier_sortie, exist_ok=True)
     fichiers_txt = [


### PR DESCRIPTION
## Summary
- unify path for competitor sheets to `fiches_concurrents`
- update GUI code to look in the new folder

## Testing
- `python -m py_compile application_definitif.py core/scraper.py main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445b2c81688330a18f05f23f7d0c64