### PR TITLE
Improve feedback when loading scrapers

### DIFF
--- a/NEW_APPLICATION_EN_DEV/inspecteur_selector/inspecteur_selector.py
+++ b/NEW_APPLICATION_EN_DEV/inspecteur_selector/inspecteur_selector.py
@@ -83,7 +83,11 @@ def load_scrapers() -> Dict[str, Scraper]:
                 mod = importlib.import_module(mod_name)
             func = getattr(mod, func_name)
             scrapers[name] = func  # type: ignore[assignment]
-        except Exception:
+        except (ImportError, AttributeError) as exc:
+            print(f"Failed to load scraper '{spec}': {exc}")
+            continue
+        except Exception as exc:  # pragma: no cover - defensive
+            print(f"Error loading scraper '{spec}': {exc}")
             continue
     return scrapers
 


### PR DESCRIPTION
## Summary
- report failures when dynamic scraper imports fail in `load_scrapers`

## Testing
- `python -m py_compile NEW_APPLICATION_EN_DEV/inspecteur_selector/inspecteur_selector.py`

------
https://chatgpt.com/codex/tasks/task_e_68445d17abcc83309a6c739bfa0b91b0