### PR TITLE
Integrate qt-material theme

### DIFF
--- a/application_definitif.py
+++ b/application_definitif.py
@@ -38,6 +38,18 @@ from core.scraper import (
 )
 from core.utils import charger_liens_avec_id_fichier
 from ui.widgets import AnimatedProgressBar
+from qt_material import apply_stylesheet
+
+MATERIAL_THEME = "dark_purple.xml"
+
+
+def apply_material_theme(
+    app: QApplication,
+    theme: str = MATERIAL_THEME,
+) -> None:
+    """Apply the qt-material theme to the given QApplication instance."""
+    apply_stylesheet(app, theme=theme)
+
 
 DARK_STYLE = """
 QMainWindow { background-color: #2b2b2b; color: #eee; }
@@ -546,7 +558,9 @@ La barre de progression et le minuteur indiquent l'avancement."""
 
     def toggle_log(self, checked: bool) -> None:
         self.log_area.setVisible(checked)
-        self.toggle_log_btn.setArrowType(Qt.DownArrow if checked else Qt.RightArrow)
+        self.toggle_log_btn.setArrowType(
+            Qt.DownArrow if checked else Qt.RightArrow
+        )
 
     def append_log(self, text: str) -> None:
         self.log_area.moveCursor(QTextCursor.End)
@@ -576,6 +590,7 @@ La barre de progression et le minuteur indiquent l'avancement."""
 
 def main() -> None:
     app = QApplication(sys.argv)
+    apply_material_theme(app)
     win = MainWindow()
     win.show()
     sys.exit(app.exec())

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ tqdm
 flake8
 webdriver-manager
 qtawesome
+qt-material
 websockets


### PR DESCRIPTION
## Summary
- integrate qt-material theme via `apply_stylesheet`
- add helper function `apply_material_theme`
- apply theme when creating the application
- include qt-material in requirements

## Testing
- `pip install -q -r requirements.txt`
- `flake8` *(fails: line length issues in `NEW_APPLICATION_EN_DEV` modules)*

------
https://chatgpt.com/codex/tasks/task_e_684460cb98d88330b65d1b9c91f21456