### PR TITLE
Improve scraper documentation and helper structure

### DIFF
--- a/PATCH_REPORT.txt
+++ b/PATCH_REPORT.txt
@@ -10,3 +10,9 @@ Corrections appliquées :
   `extras_require` (installation possible avec `pip install .[yaml]`).
 - Raccourcissement de plusieurs lignes longues et ajout d'un test `flake8`
   pour vérifier le style de code.
+- Ajout de docstrings de module pour `main.py`, `core/scraper.py`,
+  `core/utils.py` et `config_loader.py`.
+- Documentation des fonctions publiques dans `core/scraper.py` et
+  `core/utils.py`.
+- Factorisation de `scrap_produits_par_ids` et `scrap_fiches_concurrents` en
+  petits helpers privés (extraction du prix, des variantes, parsing HTML).

--- a/config_loader.py
+++ b/config_loader.py
@@ -1,3 +1,5 @@
+"""Utility to load configuration files in JSON or YAML format."""
+
 import os
 import json
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,24 +1,28 @@
+"""Utility helpers for cleaning text and loading product mappings."""
+
 import os
 import re
 import unicodedata
 
 
 def clean_name(name: str) -> str:
-    nfkd = unicodedata.normalize('NFKD', name)
-    only_ascii = nfkd.encode('ASCII', 'ignore').decode('ASCII')
-    return only_ascii.lower().replace('-', ' ').strip()
+    """Return a normalized string suitable for folder names."""
+    nfkd = unicodedata.normalize("NFKD", name)
+    only_ascii = nfkd.encode("ASCII", "ignore").decode("ASCII")
+    return only_ascii.lower().replace("-", " ").strip()
 
 
 def clean_filename(name: str) -> str:
-    nfkd = unicodedata.normalize('NFKD', name)
-    only_ascii = nfkd.encode('ASCII', 'ignore').decode('ASCII')
+    """Sanitize a product title for use as a file name."""
+    nfkd = unicodedata.normalize("NFKD", name)
+    only_ascii = nfkd.encode("ASCII", "ignore").decode("ASCII")
     safe = re.sub(r"[^a-zA-Z0-9\- ]", "", only_ascii)
     safe = safe.replace(" ", "-").lower()
     return safe
 
 
 def charger_liens_avec_id(base_dir: str) -> dict:
-    """Charge le mapping ID -> URL depuis le fichier liens_avec_id.txt."""
+    """Load ID→URL mapping from ``liens_avec_id.txt`` in *base_dir*."""
     id_url_map = {}
     liens_id_txt = os.path.join(base_dir, "liens_avec_id.txt")
     if not os.path.exists(liens_id_txt):
@@ -34,7 +38,7 @@ def charger_liens_avec_id(base_dir: str) -> dict:
 
 
 def charger_liens_avec_id_fichier(fichier: str) -> dict:
-    """Charge le mapping ID -> URL depuis un fichier texte fourni."""
+    """Load ID→URL mapping from an explicit text file path."""
     id_url_map = {}
     if not os.path.exists(fichier):
         print(f"Fichier introuvable : {fichier}")
@@ -49,6 +53,7 @@ def charger_liens_avec_id_fichier(fichier: str) -> dict:
 
 
 def extraire_ids_depuis_input(input_str: str) -> list:
+    """Return a list of IDs from a range expression like ``A1-A3``."""
     try:
         start_id, end_id = input_str.upper().split("-")
         start_num = int(start_id[1:])

--- a/main.py
+++ b/main.py
@@ -1,12 +1,15 @@
+"""Command line interface to launch scraping routines."""
+
 import os
-from core.utils import charger_liens_avec_id, extraire_ids_depuis_input
 import sys
 import logging
+
 from core.scraper import (
     scrap_produits_par_ids,
     scrap_fiches_concurrents,
     export_fiches_concurrents_json,
 )
+from core.utils import charger_liens_avec_id, extraire_ids_depuis_input
 
 
 def demander_base_dir() -> str:


### PR DESCRIPTION
## Summary
- document main entry point
- document and refactor scraper helpers
- add docstrings to utilities
- document config loader
- update patch report

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c95e66708330ba9ccb74a6b36de7