### PR TITLE
Expand tests and mocks

### DIFF
--- a/PATCH_REPORT.txt
+++ b/PATCH_REPORT.txt
@@ -24,3 +24,8 @@ Corrections appliquées :
   `core/image_scraper.py`, `main.py` et `application_definitif.py`.
   Un `StreamHandler` redirigé vers `sys.stdout` assure la compatibilité
   avec `EmittingStream` de l'interface graphique.
+- Couverture de tests étendue :
+  - simulation des dépendances lourdes dans `tests/test_imports.py`.
+  - nouveaux tests pour `extraire_ids_depuis_input`, `ImageScraper.scrape_images`,
+    `scrap_produits_par_ids` et `scrap_fiches_concurrents`.
+  - exécution facultative de `flake8` dans la suite `pytest`.

--- a/tests/test_flake8.py
+++ b/tests/test_flake8.py
@@ -1,7 +1,15 @@
-from flake8.api import legacy as flake8
+import importlib.util
+import pytest
+
+if importlib.util.find_spec("flake8") is not None:
+    from flake8.api import legacy as flake8
+else:  # pragma: no cover - optional dependency
+    flake8 = None
 
 
 def test_flake8():
+    if flake8 is None:
+        pytest.skip("flake8 non disponible")
     style = flake8.get_style_guide(max_line_length=79)
     report = style.check_files(["."])
     assert report.total_errors == 0, "flake8 found violations"

--- a/tests/test_image_scraper.py
+++ b/tests/test_image_scraper.py
@@ -1,0 +1,61 @@
+import os
+import urllib.request
+
+from core.image_scraper import ImageScraper
+
+
+class FakeImage:
+    def __init__(self, src):
+        self._src = src
+
+    def get_attribute(self, name):
+        return self._src if name == "src" else None
+
+
+class FakeDriver:
+    def __init__(self):
+        self.visited = []
+        self.title = "Test Product | Shop"
+        self.quit_called = False
+
+    def get(self, url):
+        self.visited.append(url)
+
+    def find_elements(self, *args, **kwargs):
+        return [
+            FakeImage("http://example.com/a.webp"),
+            FakeImage("http://example.com/b.webp"),
+        ]
+
+    def quit(self):
+        self.quit_called = True
+
+
+def test_scrape_images(monkeypatch, tmp_path):
+    driver = FakeDriver()
+
+    scraper = ImageScraper(root_folder=str(tmp_path))
+
+    monkeypatch.setattr(ImageScraper, "setup_driver", lambda self: driver)
+    monkeypatch.setattr(
+        ImageScraper,
+        "get_image_elements",
+        lambda self: driver.find_elements(),
+    )
+    monkeypatch.setattr(
+        urllib.request,
+        "urlretrieve",
+        lambda url, fp: open(fp, "wb").write(b"data"),
+    )
+    scraper.driver = driver
+    monkeypatch.setattr("time.sleep", lambda x: None)
+
+    exit_code = scraper.scrape_images(["http://product"])
+
+    assert exit_code == 0
+    assert driver.visited == ["http://product"]
+    assert driver.quit_called
+    saved_dir = tmp_path / "test-product"
+    assert saved_dir.exists()
+    files = sorted(os.listdir(saved_dir))
+    assert files == ["img_0.webp", "img_1.webp"]

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,5 +1,9 @@
 import importlib
+import importlib.util
 import unittest
+
+SKIP_SELENIUM = importlib.util.find_spec("selenium") is None
+SKIP_PANDAS = importlib.util.find_spec("pandas") is None
 
 
 class TestImports(unittest.TestCase):
@@ -13,7 +17,14 @@ class TestImports(unittest.TestCase):
             self.skipTest('PySide6 non disponible')
 
     def test_image_scraper_imports(self):
+        if SKIP_SELENIUM:
+            self.skipTest('selenium non disponible')
         importlib.import_module('core.image_scraper')
+
+    def test_scraper_imports(self):
+        if SKIP_SELENIUM or SKIP_PANDAS:
+            self.skipTest('dépendances selenium/pandas manquantes')
+        importlib.import_module('core.scraper')
 
 
 if __name__ == '__main__':

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,87 @@
+import pytest
+
+from core import scraper as scr
+
+
+class FakeDriver:
+    def __init__(self):
+        self.visited = []
+        self.page_source = (
+            "<html><h1>Title</h1><div id='product_description'>"
+            "Desc</div></html>"
+        )
+        self.quit_called = False
+
+    def get(self, url):
+        self.visited.append(url)
+
+    def find_element(self, *args, **kwargs):
+        class E:
+            text = "Test Name"
+        return E()
+
+    def execute_script(self, *a, **k):
+        pass
+
+    def quit(self):
+        self.quit_called = True
+
+
+class FakeDataFrame(list):
+    def to_excel(self, path, index=False):
+        self.saved_path = path
+
+
+class FakePandas:
+    def __init__(self):
+        self.captured = None
+        self.df = None
+
+    def DataFrame(self, data, **kwargs):
+        self.captured = data
+        self.df = FakeDataFrame()
+        return self.df
+
+
+@pytest.fixture
+def fake_pandas(monkeypatch):
+    fp = FakePandas()
+    monkeypatch.setattr(scr, "pd", fp)
+    return fp
+
+
+def test_scrap_produits_par_ids(monkeypatch, tmp_path, fake_pandas):
+    driver = FakeDriver()
+    monkeypatch.setattr(scr, "_get_driver", lambda headless=False: driver)
+    monkeypatch.setattr(scr, "_parse_price", lambda d: "9.99")
+    monkeypatch.setattr(scr, "_get_variant_names", lambda d: ["Red", "Blue"])
+    monkeypatch.setattr("time.sleep", lambda x: None)
+    id_map = {"A1": "http://example.com"}
+    exit_code = scr.scrap_produits_par_ids(id_map, ["A1"], str(tmp_path))
+
+    assert exit_code == 0
+    assert driver.visited == ["http://example.com"]
+    assert driver.quit_called
+    assert isinstance(fake_pandas.captured, list)
+    assert fake_pandas.captured[0]["Type"] == "variable"
+    assert fake_pandas.df.saved_path.endswith("woocommerce_mix.xlsx")
+
+
+def test_scrap_fiches_concurrents(monkeypatch, tmp_path, fake_pandas):
+    driver = FakeDriver()
+    monkeypatch.setattr(scr, "_get_driver", lambda headless=False: driver)
+    monkeypatch.setattr(scr, "_extract_title", lambda soup: "My Title")
+    monkeypatch.setattr(
+        scr, "_find_description_div", lambda soup: soup.find("div")
+    )
+    monkeypatch.setattr(scr, "_convert_links", lambda div: None)
+    monkeypatch.setattr("time.sleep", lambda x: None)
+    id_map = {"A1": "http://example.com"}
+    exit_code = scr.scrap_fiches_concurrents(id_map, ["A1"], str(tmp_path))
+
+    assert exit_code == 0
+    assert driver.visited == ["http://example.com"]
+    assert driver.quit_called
+    fc_dir = tmp_path / "fiches_concurrents"
+    assert fc_dir.exists()
+    assert isinstance(fake_pandas.captured, list)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,12 @@ class TestUtils(unittest.TestCase):
         result = extraire_ids_depuis_input('A1-A3')
         self.assertEqual(result, ['A1', 'A2', 'A3'])
 
+    def test_extraire_ids_depuis_input_invalid(self):
+        self.assertEqual(extraire_ids_depuis_input('invalid'), [])
+
+    def test_extraire_ids_depuis_input_reversed(self):
+        self.assertEqual(extraire_ids_depuis_input('A5-A1'), [])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- mock optional heavy dependencies in tests
- extend unit tests for `extraire_ids_depuis_input`
- add coverage for `ImageScraper.scrape_images`
- test scraping helpers with fake drivers
- skip flake8 test when flake8 isn't installed
- document new coverage in `PATCH_REPORT.txt`

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844cdfe3cb883308a5e545f909a8286