### PR TITLE
Add optional dependency skips

### DIFF
--- a/tests/test_image_scraper.py
+++ b/tests/test_image_scraper.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip("selenium")
+
 import os
 import urllib.request
 

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,4 +1,6 @@
 import pytest
+pytest.importorskip("selenium")
+pytest.importorskip("pandas")
 
 from core import scraper as scr
 


### PR DESCRIPTION
## Summary
- ensure selenium dependency is optional for image scraping tests
- make scraper tests optional on selenium and pandas

## Testing
- `pytest -q`
- `pytest tests/test_image_scraper.py -k test_scrape_images -vv` *(with selenium uninstalled)*
- `pytest tests/test_scraper.py -k scrap_produits_par_ids -vv` *(with selenium uninstalled)*

------
https://chatgpt.com/codex/tasks/task_e_6844d46dacc8833097350902a0593c07