### PR TITLE
Replace exit with sys.exit

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
 
     if not ids_selectionnes:
         logger.warning("\u26d4 Aucun ID valide fourni. Arr\u00eat du script.")
-        exit()
+        sys.exit()
 
     if input(
         "\u25b6\ufe0f Lancer le scraping des variantes ? (oui/non): "


### PR DESCRIPTION
## Summary
- use `sys.exit()` instead of builtin `exit()` when no IDs are provided

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684557a40fe48330a3d608e294b63105