### PR TITLE
Add collection link scraper with CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,3 +257,17 @@ python scraper_images.py --config config.yaml
 - `--root` : dossier de destination des images
 
 Les arguments passés en ligne de commande écrasent les valeurs du fichier de configuration.
+
+## Lancer `scraper_links.py` en ligne de commande
+
+Le script `scraper_links.py` permet de récupérer les paires nom/lien d'une page en une commande.
+
+```bash
+python scraper_links.py --url https://exemple.com --selector "a.product" --output liens.csv
+```
+
+### Options CLI principales
+
+- `--url` : page à analyser
+- `--selector` : sélecteur CSS à appliquer
+- `--output` : fichier CSV de destination (`links.csv` par défaut)

--- a/core/collection_scraper.py
+++ b/core/collection_scraper.py
@@ -1,0 +1,44 @@
+"""Simple scraper for name/link pairs using requests."""
+
+import csv
+import logging
+
+import requests
+from bs4 import BeautifulSoup
+
+logger = logging.getLogger(__name__)
+
+
+def scrape_collection(url: str, selector: str, output_csv: str) -> int:
+    """Fetch elements matching ``selector`` on ``url`` and save name/link pairs."""
+    exit_code = 0
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+    except Exception as err:
+        logger.error("Failed to fetch %s: %s", url, err)
+        return 1
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+    seen = set()
+    rows = []
+    for elem in soup.select(selector):
+        name = elem.get_text(strip=True)
+        link = elem.get("href", "")
+        if not name or name.isnumeric():
+            continue
+        key = (name, link)
+        if key in seen:
+            continue
+        seen.add(key)
+        rows.append({"name": name, "link": link})
+
+    try:
+        with open(output_csv, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=["name", "link"])
+            writer.writeheader()
+            writer.writerows(rows)
+    except Exception as err:
+        logger.error("Failed to write CSV %s: %s", output_csv, err)
+        exit_code = 1
+    return exit_code

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+requests
 pyside6
 selenium
 pandas

--- a/scraper_links.py
+++ b/scraper_links.py
@@ -1,0 +1,25 @@
+import argparse
+from core.collection_scraper import scrape_collection
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Scrape name/link pairs from a collection page"
+    )
+    parser.add_argument("--url", required=True, help="Page URL to scrape")
+    parser.add_argument(
+        "--selector",
+        required=True,
+        help="CSS selector for items containing links",
+    )
+    parser.add_argument(
+        "--output",
+        default="links.csv",
+        help="Destination CSV file",
+    )
+    args = parser.parse_args()
+    scrape_collection(args.url, args.selector, args.output)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/tests/test_collection_scraper.py
+++ b/tests/test_collection_scraper.py
@@ -1,0 +1,47 @@
+import csv
+import requests
+from core.collection_scraper import scrape_collection
+
+
+class FakeResponse:
+    def __init__(self, text):
+        self.text = text
+
+    def raise_for_status(self):
+        pass
+
+
+def test_scrape_collection_basic(monkeypatch, tmp_path):
+    html = """
+    <html>
+      <a href='http://a'>Item A</a>
+      <a href='http://b'>123</a>
+      <a href='http://a'>Item A</a>
+      <div class='x'><a href='http://d'>Item D</a></div>
+    </html>
+    """
+
+    monkeypatch.setattr(requests, 'get', lambda url, timeout=10: FakeResponse(html))
+    out = tmp_path / 'res.csv'
+    exit_code = scrape_collection('http://example', 'a', str(out))
+
+    assert exit_code == 0
+    with open(out, newline='', encoding='utf-8') as f:
+        rows = list(csv.reader(f))
+
+    assert rows == [
+        ['name', 'link'],
+        ['Item A', 'http://a'],
+        ['Item D', 'http://d'],
+    ]
+
+
+def test_scrape_collection_custom_selector(monkeypatch, tmp_path):
+    html = "<div class='x'><a href='http://d'>Item D</a></div>"
+    monkeypatch.setattr(requests, 'get', lambda url, timeout=10: FakeResponse(html))
+    out = tmp_path / 'res.csv'
+    exit_code = scrape_collection('http://example', 'div.x a', str(out))
+    assert exit_code == 0
+    with open(out, newline='', encoding='utf-8') as f:
+        rows = list(csv.reader(f))
+    assert rows[-1] == ['Item D', 'http://d']

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -26,6 +26,9 @@ class TestImports(unittest.TestCase):
             self.skipTest('dépendances selenium/pandas manquantes')
         importlib.import_module('core.scraper')
 
+    def test_collection_scraper_imports(self):
+        importlib.import_module('core.collection_scraper')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- implement `scrape_collection` for scraping name/link pairs using requests
- expose new CLI `scraper_links.py`
- document the CLI usage in README
- include unit tests for the new scraper
- ensure module import coverage and add requests to requirements

## Testing
- `python -m pytest -q`
- `python -m pytest tests/test_flake8.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684559193a988330956706706edf50f3