### PR TITLE
Improve log copy behavior

### DIFF
--- a/application_definitif.py
+++ b/application_definitif.py
@@ -650,7 +650,11 @@ La barre de progression et le minuteur indiquent l'avancement."""
 
     def copy_log(self) -> None:
         clipboard = QApplication.clipboard()
-        clipboard.setText(self.log_area.toPlainText())
+        if self.log_area.isVisible():
+            text = self.log_area.toPlainText()
+        else:
+            text = "".join(self.internal_logs)
+        clipboard.setText(text)
         self.statusBar().showMessage("Journal copié !", 3000)
 
     def clear_log(self) -> None:


### PR DESCRIPTION
## Summary
- record log entries in `MainWindow.internal_logs`
- copy from `internal_logs` if the log widget is hidden

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684564644a0883309ac965e74c55d3a2