### PR TITLE
Add simple universal scraper module

### DIFF
--- a/NEW_APPLICATION_EN_DEV/__init__.py
+++ b/NEW_APPLICATION_EN_DEV/__init__.py
@@ -1,0 +1,1 @@
+"""Experimental scraping modules."""

--- a/NEW_APPLICATION_EN_DEV/scraper_universel.py
+++ b/NEW_APPLICATION_EN_DEV/scraper_universel.py
@@ -1,0 +1,93 @@
+"""Simple configurable scraper for e-commerce product pages."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import requests
+from bs4 import BeautifulSoup
+
+try:
+    from lxml import html  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    html = None
+
+logger = logging.getLogger(__name__)
+
+
+def _load_mapping(mapping: Optional[Dict[str, str]] = None,
+                  mapping_file: Optional[str] = None) -> Dict[str, str]:
+    """Return a mapping dict loaded from *mapping_file* or *mapping*."""
+    if mapping:
+        return mapping
+    if not mapping_file:
+        raise ValueError("No mapping provided")
+
+    path = Path(mapping_file)
+    if not path.exists():
+        raise FileNotFoundError(mapping_file)
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() in {".yaml", ".yml"}:
+        try:
+            import yaml  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise ImportError("pyyaml required for YAML mapping") from exc
+        return yaml.safe_load(text)
+    return json.loads(text)
+
+
+def _extract_with_css(soup: BeautifulSoup, selector: str) -> Optional[str]:
+    elems = soup.select(selector)
+    if not elems:
+        return None
+    elem = elems[0]
+    if elem.name == "img" and elem.has_attr("src"):
+        return elem["src"].strip()
+    text = elem.get_text(strip=True)
+    return text or None
+
+
+def _extract_with_xpath(tree: "html.HtmlElement", selector: str) -> Optional[str]:
+    if tree is None:
+        return None
+    results = tree.xpath(selector)
+    if not results:
+        return None
+    result = results[0]
+    if hasattr(result, "text_content"):
+        return result.text_content().strip()
+    if isinstance(result, str):
+        return result.strip()
+    return str(result).strip()
+
+
+def scrap_fiche_generique(url: str,
+                          mapping: Optional[Dict[str, str]] = None,
+                          *,
+                          mapping_file: Optional[str] = None,
+                          timeout: int = 10) -> Dict[str, Any]:
+    """Return the scraped fields defined in *mapping* from *url*."""
+    mapping = _load_mapping(mapping, mapping_file)
+
+    resp = requests.get(url, timeout=timeout)
+    resp.raise_for_status()
+    page = resp.text
+    soup = BeautifulSoup(page, "html.parser")
+    tree = html.fromstring(page) if html else None
+
+    data: Dict[str, Any] = {}
+    for field, selector in mapping.items():
+        value: Optional[str] = None
+        if selector.lstrip().startswith("/"):
+            value = _extract_with_xpath(tree, selector)
+        else:
+            value = _extract_with_css(soup, selector)
+
+        if not value:
+            logger.warning("Champ manquant: %s via %s", field, selector)
+        data[field] = value
+    return data
+

--- a/tests/test_universal_scraper.py
+++ b/tests/test_universal_scraper.py
@@ -1,0 +1,36 @@
+import json
+from NEW_APPLICATION_EN_DEV.scraper_universel import scrap_fiche_generique
+
+
+def test_scrap_fiche_generique(tmp_path, requests_mock):
+    html = (
+        "<html>"
+        "<h1 class='product-title'>Title</h1>"
+        "<span class='product-price'><b>9.99</b></span>"
+        "<p class='desc'>Hello</p>"
+        "<img class='main-img' src='img.jpg'/>"
+        "</html>"
+    )
+    requests_mock.get('http://example.com', text=html)
+    mapping = {
+        'title': 'h1.product-title',
+        'price': '.product-price b',
+        'desc': '.desc',
+        'image': 'img.main-img'
+    }
+    data = scrap_fiche_generique('http://example.com', mapping)
+    assert data['title'] == 'Title'
+    assert data['price'] == '9.99'
+    assert data['desc'] == 'Hello'
+    assert data['image'] == 'img.jpg'
+
+
+def test_mapping_file(tmp_path, requests_mock):
+    html = '<html><h1>Title</h1></html>'
+    requests_mock.get('http://example.com', text=html)
+    mapping = {'title': 'h1'}
+    path = tmp_path / 'map.json'
+    path.write_text(json.dumps(mapping))
+    data = scrap_fiche_generique('http://example.com', mapping_file=str(path))
+    assert data['title'] == 'Title'
+


### PR DESCRIPTION
## Summary
- add NEW_APPLICATION_EN_DEV directory for dev modules
- implement `scraper_universel.py` to fetch fields from product pages using CSS or XPath selectors with optional mapping files
- include tests covering the new scraper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68459d6238088330b82bc3754dcb13a8