### PR TITLE
Add CLI to universal scraper

### DIFF
--- a/NEW_APPLICATION_EN_DEV/scraper_universel.py
+++ b/NEW_APPLICATION_EN_DEV/scraper_universel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import logging
 from pathlib import Path
@@ -90,4 +91,33 @@ def scrap_fiche_generique(url: str,
             logger.warning("Champ manquant: %s via %s", field, selector)
         data[field] = value
     return data
+
+
+def main() -> None:
+    """Simple command line interface for :func:`scrap_fiche_generique`."""
+    parser = argparse.ArgumentParser(description="Universal scraper")
+    parser.add_argument("--url", required=True, help="URL of the page")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--mapping-file",
+        help="JSON or YAML mapping file",
+    )
+    group.add_argument(
+        "--mapping",
+        help="Mapping JSON string",
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+
+    mapping = json.loads(args.mapping) if args.mapping else None
+    data = scrap_fiche_generique(
+        args.url, mapping, mapping_file=args.mapping_file
+    )
+    print(json.dumps(data, ensure_ascii=False))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()
 


### PR DESCRIPTION
## Summary
- add argparse-based CLI to `scraper_universel.py`
- return JSON when executed as script
- cover new CLI in unit tests using a tiny HTTP server

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a02ac32c8330aceac4e47b00f153