### PR TITLE
Improve parser handling in scraper_universel

### DIFF
--- a/NEW_APPLICATION_EN_DEV/scraper_universel.py
+++ b/NEW_APPLICATION_EN_DEV/scraper_universel.py
@@ -81,7 +81,8 @@ def scrap_fiche_generique(url: str,
         return {}
 
     page = resp.text
-    soup = BeautifulSoup(page, "html.parser")
+    bs_parser = "lxml" if html else "html.parser"
+    soup = BeautifulSoup(page, bs_parser)
     tree = html.fromstring(page) if html else None
 
     data: Dict[str, Any] = {}


### PR DESCRIPTION
## Summary
- use `lxml` with BeautifulSoup when available
- check which parser is selected in universal scraper tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a23779508330a8ab83c5d55f278d