### PR TITLE
Add universal scraper prototype

### DIFF
--- a/NEW_APPLICATION_EN_DEV/README.txt
+++ b/NEW_APPLICATION_EN_DEV/README.txt
@@ -1,0 +1,31 @@
+Scraper universel
+=================
+
+Ce dossier contient un prototype isolé permettant d'extraire des champs
+arbitraires depuis n'importe quelle page web.
+
+Utilisation rapide
+------------------
+
+Pour lancer un test automatique (page de démonstration) :
+
+```
+python -m NEW_APPLICATION_EN_DEV.scraper_universel
+```
+
+Pour extraire vos propres pages :
+
+```
+python -m NEW_APPLICATION_EN_DEV.scraper_universel --url "https://exemple.com" \
+    --mapping '{"titre": "h1", "prix": ".price"}'
+```
+
+Ou bien :
+
+```
+python -m NEW_APPLICATION_EN_DEV.scraper_universel --url "https://exemple.com" \
+    --mapping-file mapping.json
+```
+
+Le mapping est un fichier JSON ou YAML associant un nom de champ à un
+sélecteur CSS ou XPath.


### PR DESCRIPTION
## Summary
- implement a reusable `extract_fields` scraper in `NEW_APPLICATION_EN_DEV`
- keep `scrap_fiche_generique` as a wrapper
- provide a CLI demo when run without parameters
- document usage in `NEW_APPLICATION_EN_DEV/README.txt`

## Testing
- `pip install requests_mock`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ce60fa588330bcfefbcf580d28a0