### PR TITLE
Ensure qwebchannel.js injection works from any directory

### DIFF
--- a/NEW_APPLICATION_EN_DEV/ui_scraper_demo.py
+++ b/NEW_APPLICATION_EN_DEV/ui_scraper_demo.py
@@ -14,6 +14,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import QUrl, QObject, Slot
 from PySide6.QtWebEngineWidgets import QWebEngineView
 from PySide6.QtWebChannel import QWebChannel
+from pathlib import Path
 
 import sys
 import os
@@ -200,7 +201,8 @@ class ScraperDemo(QWidget):
     def inject_script(self) -> None:
         """Inject the click capture script into the loaded page."""
         try:
-            with open("qwebchannel.js", "r", encoding="utf-8") as f:
+            path = Path(__file__).resolve().parents[1] / "qwebchannel.js"
+            with open(path, "r", encoding="utf-8") as f:
                 self.web_view.page().runJavaScript(f.read())
         except Exception:
             pass


### PR DESCRIPTION
## Summary
- load `qwebchannel.js` using an absolute path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f25ffa3083308c8337d66531e8d8